### PR TITLE
161 Don't use `globalVariables`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@ _pkgdown.yaml
 docs
 ^.lintr
 ^.gitlab-ci.yml
+CODE_OF_CONDUCT.md
+SECURITY.md


### PR DESCRIPTION
closes #161 

global variables are already dealt with except the `.` pronoun from `magrittr`.

thank you for the review