### PR TITLE
289 fix note

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 # as we use NSE
-globalVariables(c("."))
+globalVariables(c(".",":=","res",".env"))
 
 #' Retrieve labels for certain variables
 #'
@@ -250,7 +250,10 @@ smart_prune <- function(tlg) {
 #' @param new (`string`) the name of the new column. If `NULL` the concatenation of `cols` separated by `sep` is used.
 #'
 #' @return `dm` object with a united column.
-#'
+#' @importFrom rlang :=
+#' @importFrom rlang .data
+#' @importFrom rlang .env
+#' 
 #' @examples
 #' \dontrun{
 #' x <- dm_unite(dm::dm_nycflights13(), "airlines", c("carrier", "name"), new = "FUSION")


### PR DESCRIPTION
close #289 

I found the internal function dm_unite() was located in R/utils.R script and a note popped up if I ran devtools::check() saying that undefined functions or variables exist. It is noted that the check note is not exactly the same as what has been described in issue #289, presumably as the package has been updated frequently ever since the ticket was opened 20ish days ago. 

I updated the utils.globalVariables on the top of the script. In addition, I've added rlang under the imports since it's also in DESCRIPTION and a NAMESPACE directive.


Let's see how it works...