### PR TITLE
add prototype for listing template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ inst/doc
 docs
 temp
 *.bak
+.Renviron
+.Rprofile

--- a/R/dml01.R
+++ b/R/dml01.R
@@ -1,0 +1,41 @@
+# dml01_1 ----
+#' @describeIn dml01_1 Main TLG function
+#'
+#' @inheritParams gen_args
+#' @param dataset (`string`) the name of a table in the `adam_db` object.
+#' @param cols (`character`) the variables to be displayed in listing.
+#' @param key_cols (`character`) the variables to be displayed as key columns in listing.
+#'
+#' @export
+#'
+#' @examples
+#' library(dm)
+#' library(magrittr)
+#'
+#' db <- syn_data %>%
+#'   dml01_1_pre()
+#'
+#' dml01_1_main(db)
+dml01_1_main <- function(adam_db, dataset, cols = c("USUBJID", "ASR"), key_cols = NULL, deco = std_deco("DMT01")) {
+  as_listing(
+    adam_db[[dataset]],
+    cols = cols,
+    key_cols = key_cols,
+    main_titl = deco$title,
+    subtitles = deco$subtitles,
+    main_footer = deco$main_footer
+  )
+}
+
+dml01_1_pre <- function(adam_db, ...) {
+  adam_db %>%
+    zoom_to("adsl") %>%
+    mutate(ASR = sprintf("%s/%s/%s", AGE, SEX, RACE)) %>%
+    dm_update_zoomed()
+}
+
+dml01_1_post <- function(tlg, ...) {
+  tlg
+}
+
+dml01_1 <- chevron_l(main = dml01_1_main, preprocess = dml01_1_pre, postprocess = dml01_1_post)


### PR DESCRIPTION
there are some points that we need to carefully evaluate:

composite variables. AGE/SEX/RACE are usually combined together in listings, and we need to find a way to better help users to define this. 

we either use some formats to derive it like
```{yaml}
ASR:
  format: "%s/%s/%s"
  vars: ["AGE", ”SEX", "RACE"]
```
or, we have to derive it in preprocessing. The biggest problem is, before it is derived, the argument of column variables, "ASR"(or whatever) is meaningless. This is very strange and can cause a lot of confusion. The same apply to aet01 templates where the flags are derived automatically; the arguments seem so counterintuitive! ( the logic for rlistings is that, we use data frame variables to create listings, the variable should be there)

If we want to make things explicit, then we probably need to export that preprocessing part in the script (and we should not overwrite the existing variables). an example is, for aet01, if a user need aesi other than smq01/smq02/cq01, how should the user customize? If the user just modify the argument, things will go wrong. He has to put some preprocessing code in the script( I don't think users should update template@preprocessing at this time because it is much more straightforward to use dplyr things!)


For listings, I really doubt if we should create multiple templates for a simple listing.

@barnett11 @crazycatandy @BFalquet @duanx9 looking for your opinion



