### PR TITLE
[skip vbump] 514 new release tag, by 2023-05-24

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: chevron
 Title: Standard TLGs for Clinical Trials Reporting
-Version: 0.1.4.9020
+Version: 0.1.5
 Date: 2023-05-24
 Authors@R: c(
     person("Benoit", "Falquet", , "benoit.falquet@roche.com", role = c("aut", "cre")),
@@ -22,7 +22,7 @@ Depends:
 Imports:
     checkmate (>= 2.0),
     dplyr,
-    dunlin (>= 0.1.2),
+    dunlin (>= 0.1.3),
     forcats (>= 1.0.0),
     formatters (>= 0.5.0),
     ggplot2 (>= 3.4.0),
@@ -45,13 +45,6 @@ Suggests:
     tidyr
 VignetteBuilder:
     knitr
-Remotes:
-    insightsengineering/dunlin@*release,
-    insightsengineering/formatters@*release,
-    insightsengineering/nestcolor@*release,
-    insightsengineering/rlistings@*release,
-    insightsengineering/rtables@*release,
-    insightsengineering/tern@*release
 Config/Needs/website: insightsengineering/nesttemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# chevron 0.1.4.9020
+# chevron 0.1.5
 
 * Remove the usage of `dm` class of object. The chevron functions now expect list of `data.frame` as `adam_db` argument. 
 * Remove variants in template names.


### PR DESCRIPTION
https://github.com/insightsengineering/chevron-tasks/issues/5

update news and description (including requirement for dunlin 0.1.3)