### PR TITLE
update aet10

### DIFF
--- a/man/aet10.Rd
+++ b/man/aet10.Rd
@@ -11,11 +11,17 @@
 An object of class \code{chevron_t} of length 1.
 }
 \usage{
-aet10_main(adam_db, arm_var = "ACTARM", lbl_overall = NULL, ...)
+aet10_main(
+  adam_db,
+  arm_var = "ACTARM",
+  row_split_var = NULL,
+  lbl_overall = NULL,
+  ...
+)
 
 aet10_pre(adam_db, ...)
 
-aet10_post(tlg, atleast = 0.05, ...)
+aet10_post(tlg, atleast = 0.05, row_split_var = NULL, ...)
 
 aet10
 }
@@ -23,6 +29,8 @@ aet10
 \item{adam_db}{(\code{list} of \code{data.frames}) object containing the \code{ADaM} datasets}
 
 \item{arm_var}{(\code{string}) variable used for column splitting}
+
+\item{row_split_var}{(\code{character}) row split variables.}
 
 \item{lbl_overall}{(\code{string}) label used for overall column, if set to \code{NULL} the overall column is omitted}
 

--- a/man/aet10_lyt.Rd
+++ b/man/aet10_lyt.Rd
@@ -4,14 +4,18 @@
 \alias{aet10_lyt}
 \title{\code{aet10} Layout}
 \usage{
-aet10_lyt(arm_var, lbl_overall, lbl_aedecod)
+aet10_lyt(arm_var, row_split_var, lbl_row_split, lbl_overall, lbl_aedecod)
 }
 \arguments{
 \item{arm_var}{(\code{string}) variable used for column splitting}
 
+\item{row_split_var}{(\code{character}) row split variables.}
+
+\item{lbl_row_split}{(\code{character}) label for \code{row_split_var}.}
+
 \item{lbl_overall}{(\code{string}) label used for overall column, if set to \code{NULL} the overall column is omitted}
 
-\item{lbl_aedecod}{(\code{character}) text label for \code{AEDECOD}.}
+\item{lbl_aedecod}{(\code{string}) text label for \code{AEDECOD}.}
 }
 \description{
 \code{aet10} Layout


### PR DESCRIPTION
close #543 

added row_split_var as argument, so you can

`run(aet10, syn_data, row_split_var = "AEBODSYS")` to further split rows by other variables.

this is an issue raised in @Teninq team, where the aet02 need a custom filtering(the overall rows need to be removed but there will be issues if we do the trimming there) so What in my mind is best to use aet10. This is a prototype and want to hear from your opinions