### PR TITLE
add withr namespace

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -287,9 +287,8 @@ test_that("get_section_div works", {
     list(chevron.section_div = 1),
     expect_identical(get_section_div(), "")
   )
- withr::with_options(
+  withr::with_options(
     list(chevron.section_div = c(1, 3)),
     expect_identical(get_section_div(), c("", NA_character_, ""))
   )
 })
-


### PR DESCRIPTION
fix integrstion test failure 
```
Error in `with_options(list(chevron.section_div = 1), expect_identical(get_section_div(), 
      ""))`: could not find function "with_options"
``` 