### PR TITLE
vbump dunlin dep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Depends:
 Imports:
     checkmate (>= 2.0),
     dplyr,
-    dunlin (>= 0.1.6),
+    dunlin (>= 0.1.6.9002),
     forcats (>= 1.0.0),
     formatters (>= 0.5.4),
     ggplot2 (>= 3.4.0),


### PR DESCRIPTION
`assert_all_tablenames` had been added in https://github.com/insightsengineering/dunlin/commit/e722aabab79f6fff76cf85dc03f81352793d9d91 after which there was a https://github.com/insightsengineering/dunlin/commit/8eb011e4519a345660f64d30a9c0b5f766587664 that vbump it into 0.1.6.9002