### PR TITLE
skip_on_ci

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chevron 0.2.5.9005
 
+* Assert `summaryvars` class in `dmt01`.
+
 # chevron 0.2.5
 
 * `MNG01` plot can now be displayed without error bars and can display a continuous temporal scale on the `x` axis.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # chevron 0.2.5.9005
 
-* Assert `summaryvars` class in `dmt01`.
+* Added assertion on class of `summaryvars` argument of `dmt01()`.
 
 # chevron 0.2.5
 

--- a/R/dmt01.R
+++ b/R/dmt01.R
@@ -44,6 +44,7 @@ dmt01_main <- function(adam_db,
   assert_string(lbl_overall, null.ok = TRUE)
   assert_character(summaryvars, null.ok = TRUE)
   assert_valid_variable(adam_db$adsl, summaryvars, na_ok = TRUE)
+  assert_valid_variable(adam_db$adsl, summaryvars, types = list(c("numeric", "factor", "logical")))
   assert_valid_variable(adam_db$adsl, c("USUBJID", arm_var), types = list(c("character", "factor")))
   assert_list(stats, types = "character")
   assert_list(precision, types = "integerish", names = "unique")

--- a/tests/testthat/test-dmt01.R
+++ b/tests/testthat/test-dmt01.R
@@ -15,6 +15,20 @@ test_that("dmt01 can handle numeric NA values", {
   expect_snapshot(cat(export_as_txt(res, lpp = 100)))
 })
 
+test_that("dmt01 returns an error when variables are of the wrong type", {
+  proc_data <- syn_data
+  proc_data$adsl <- proc_data$adsl %>%
+    mutate(
+      AGEGR1 = as.character(AGEGR1)
+    )
+
+  expect_error(
+    run(dmt01, proc_data),
+    "`adam_db$adsl$AGEGR1` is not of type numeric, factor, logical",
+    fixed = TRUE
+  )
+})
+
 test_that("dmt01 works as expected with setting default precision", {
   res <- expect_silent(run(dmt01, syn_data, summaryvars = c("RACE", "AAGE", "BBMISI"), precision = list(default = 3)))
   expect_snapshot(cat(export_as_txt(res, lpp = 100)))

--- a/tests/testthat/test-mng01.R
+++ b/tests/testthat/test-mng01.R
@@ -4,6 +4,8 @@ test_that("mng01 works as expected with default argument values", {
   pre_data <- mng01_pre(syn_data, dataset = "adlb")
   res <- mng01_main(pre_data, dataset = "adlb")
   expect_list(res, len = 3, types = "ggplot")
+
+  skip_on_ci()
   vdiffr::expect_doppelganger("mng01 with default value", res[[1]])
 })
 
@@ -22,7 +24,6 @@ test_that("mng01 works as expected with custom argument values", {
     line_col = col
   )
   expect_list(res, len = 3, types = "ggplot")
-  vdiffr::expect_doppelganger("mng01 with custom theme", res[[1]], )
 
   bad_col <- c(
     "B: Placebo" = "black",
@@ -34,6 +35,9 @@ test_that("mng01 works as expected with custom argument values", {
     "Missing color matching for C: Combination",
     fixed = TRUE
   )
+
+  skip_on_ci()
+  vdiffr::expect_doppelganger("mng01 with custom theme", res[[1]], )
 })
 
 
@@ -49,17 +53,21 @@ test_that("mng01 works as expected with custom color set", {
   proc_data <- syn_data
   res <- run(mng01, proc_data, dataset = "adlb", line_col = col)
   expect_list(res, len = 3, types = "ggplot")
-  vdiffr::expect_doppelganger("run mng01 with custom color set", res[[1]])
 
-  res <- run(mng01, proc_data, dataset = "adlb", line_col = unname(col))
-  expect_list(res, len = 3, types = "ggplot")
-  vdiffr::expect_doppelganger("run mng01 with custom unnamed color set", res[[1]])
+  res2 <- run(mng01, proc_data, dataset = "adlb", line_col = unname(col))
+  expect_list(res2, len = 3, types = "ggplot")
+
+  skip_on_ci()
+  vdiffr::expect_doppelganger("run mng01 with custom color set", res[[1]])
+  vdiffr::expect_doppelganger("run mng01 with custom unnamed color set", res2[[1]])
 })
 
 test_that("mng01 works with table = NULL", {
   proc_data <- syn_data
   res <- run(mng01, proc_data, dataset = "adlb", table = NULL)
   expect_list(res, len = 3, types = "ggplot")
+
+  skip_on_ci()
   vdiffr::expect_doppelganger("run mng01 without table", res[[1]])
 })
 
@@ -72,6 +80,8 @@ test_that("mng01 works with combination of x variables", {
     x_var = c("AVISIT", "AVISITN")
   )
   expect_list(res, len = 3, types = "ggplot")
+
+  skip_on_ci()
   vdiffr::expect_doppelganger("run mng01 with combination of x variables", res[[1]])
 })
 
@@ -86,6 +96,8 @@ test_that("mng01 works with numeric x variable", {
     x_var = c("AVISITN")
   )
   expect_list(res, len = 3, types = "ggplot")
+
+  skip_on_ci()
   vdiffr::expect_doppelganger("run mng01 with numeric x variables", res[[1]])
 })
 
@@ -98,5 +110,7 @@ test_that("mng01 works with numeric jitter", {
     jitter = 0.7
   )
   expect_list(res, len = 3, types = "ggplot")
+
+  skip_on_ci()
   vdiffr::expect_doppelganger("run mng01 with jitter", res[[1]])
 })


### PR DESCRIPTION
use same strategy as `tern` to avoid constant failure of snapshot tests.

thank you for the review