### PR TITLE
ignore missmatch in grid argument

### DIFF
--- a/tests/testthat/test-kmg01.R
+++ b/tests/testthat/test-kmg01.R
@@ -1,57 +1,67 @@
 # kmg01 functions ----
 
 test_that("kmg01 works as expected", {
-  filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
-  pre_data <- expect_silent(kmg01_pre(filter_data, dataset = "adtte"))
-  raw_res <- expect_silent(kmg01_main(pre_data, dataset = "adtte"))
-  expect_true(ggplot2::is.ggplot(raw_res))
+  withr::with_options(opts_partial_match_old, {
+    filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
+    pre_data <- expect_silent(kmg01_pre(filter_data, dataset = "adtte"))
+    raw_res <- expect_silent(kmg01_main(pre_data, dataset = "adtte"))
+    expect_true(ggplot2::is.ggplot(raw_res))
+  })
 })
 
 # kmg01 ----
 
 test_that("kmg01 works as expected with custom color set", {
-  col <- c(
-    "A: Drug X" = "black",
-    "B: Placebo" = "blue",
-    "C: Combination" = "gray"
-  )
+  withr::with_options(opts_partial_match_old, {
+    col <- c(
+      "A: Drug X" = "black",
+      "B: Placebo" = "blue",
+      "C: Combination" = "gray"
+    )
 
-  filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
-  res <- expect_silent(run(kmg01, filter_data, dataset = "adtte", col = col))
-  expect_true(ggplot2::is.ggplot(res))
-  res <- expect_silent(run(kmg01, filter_data, dataset = "adtte", col = unname(col)))
-  expect_true(ggplot2::is.ggplot(res))
+    filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
+    res <- expect_silent(run(kmg01, filter_data, dataset = "adtte", col = col))
+    expect_true(ggplot2::is.ggplot(res))
+    res <- expect_silent(run(kmg01, filter_data, dataset = "adtte", col = unname(col)))
+    expect_true(ggplot2::is.ggplot(res))
+  })
 })
 
 test_that("kmg01 works if change pvalue, ties and conf level", {
-  filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
-  res <- expect_silent(run(kmg01, filter_data,
-    dataset = "adtte",
-    pval_method = "log-rank",
-    ties = "efron",
-    conf_level = 0.99
-  ))
-  expect_true(ggplot2::is.ggplot(res))
+  withr::with_options(opts_partial_match_old, {
+    filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
+    res <- expect_silent(run(kmg01, filter_data,
+      dataset = "adtte",
+      pval_method = "log-rank",
+      ties = "efron",
+      conf_level = 0.99
+    ))
+    expect_true(ggplot2::is.ggplot(res))
+  })
 })
 
 
 test_that("kmg01 works if change annotation position", {
-  filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
-  res <- expect_silent(run(kmg01, filter_data,
-    dataset = "adtte", annot_surv_med = FALSE, annot_coxph = TRUE,
-    control_annot_coxph = control_coxph_annot(x = 0.78, y = 0.9)
-  ))
-  expect_true(ggplot2::is.ggplot(res))
+  withr::with_options(opts_partial_match_old, {
+    filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
+    res <- expect_silent(run(kmg01, filter_data,
+      dataset = "adtte", annot_surv_med = FALSE, annot_coxph = TRUE,
+      control_annot_coxph = control_coxph_annot(x = 0.78, y = 0.9)
+    ))
+    expect_true(ggplot2::is.ggplot(res))
+  })
 })
 
 
 test_that("kmg01 works for stratified analysis", {
-  filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
-  res <- expect_silent(run(kmg01, filter_data,
-    dataset = "adtte", annot_surv_med = FALSE,
-    position_coxph = c(0.4, 0.5),
-    position_surv_med = c(1, 0.7),
-    strata = c("STRATA1", "STRATA2")
-  ))
-  expect_true(ggplot2::is.ggplot(res))
+  withr::with_options(opts_partial_match_old, {
+    filter_data <- dunlin::log_filter(syn_data, PARAMCD == "OS", "adtte")
+    res <- expect_silent(run(kmg01, filter_data,
+      dataset = "adtte", annot_surv_med = FALSE,
+      control_annot_coxph = tern::control_coxph_annot(x = 0.4, y = 0.5),
+      control_annot_surv_med = tern::control_surv_med_annot(x = 0.99, y = 0.7),
+      strata = c("STRATA1", "STRATA2")
+    ))
+    expect_true(ggplot2::is.ggplot(res))
+  })
 })

--- a/tests/testthat/test-mng01.R
+++ b/tests/testthat/test-mng01.R
@@ -1,116 +1,136 @@
 # mng01 functions ---
 
 test_that("mng01 works as expected with default argument values", {
-  pre_data <- mng01_pre(syn_data, dataset = "adlb")
-  res <- mng01_main(pre_data, dataset = "adlb")
-  expect_list(res, len = 3, types = "ggplot")
+  withr::with_options(opts_partial_match_old, {
+    pre_data <- mng01_pre(syn_data, dataset = "adlb")
+    res <- mng01_main(pre_data, dataset = "adlb")
+    expect_list(res, len = 3, types = "ggplot")
 
-  skip_on_ci()
-  vdiffr::expect_doppelganger("mng01 with default value", res[[1]])
+    skip_on_ci()
+    vdiffr::expect_doppelganger("mng01 with default value", res[[1]])
+  })
 })
 
 test_that("mng01 works as expected with custom argument values", {
-  col <- c(
-    "B: Placebo" = "black",
-    "A: Drug X" = "blue",
-    "C: Combination" = "gray"
-  )
+  withr::with_options(opts_partial_match_old, {
+    col <- c(
+      "B: Placebo" = "black",
+      "A: Drug X" = "blue",
+      "C: Combination" = "gray"
+    )
 
-  pre_data <- mng01_pre(syn_data, dataset = "adlb")
-  res <- mng01_main(
-    pre_data,
-    dataset = "adlb",
-    ggtheme = ggplot2::theme(axis.text.x = ggplot2::element_text(colour = "red", angle = 30, hjust = 1)),
-    line_col = col
-  )
-  expect_list(res, len = 3, types = "ggplot")
+    pre_data <- mng01_pre(syn_data, dataset = "adlb")
 
-  bad_col <- c(
-    "B: Placebo" = "black",
-    "A: Drug X" = "blue"
-  )
+    res <- mng01_main(
+      pre_data,
+      dataset = "adlb",
+      ggtheme = ggplot2::theme(axis.text.x = ggplot2::element_text(colour = "red", angle = 30, hjust = 1)),
+      line_col = col
+    )
 
-  expect_error(
-    mng01_main(pre_data, dataset = "adlb", line_col = bad_col),
-    "Missing color matching for C: Combination",
-    fixed = TRUE
-  )
+    expect_list(res, len = 3, types = "ggplot")
 
-  skip_on_ci()
-  vdiffr::expect_doppelganger("mng01 with custom theme", res[[1]], )
+    bad_col <- c(
+      "B: Placebo" = "black",
+      "A: Drug X" = "blue"
+    )
+
+    expect_error(
+      mng01_main(pre_data, dataset = "adlb", line_col = bad_col),
+      "Missing color matching for C: Combination",
+      fixed = TRUE
+    )
+
+    skip_on_ci()
+    vdiffr::expect_doppelganger("mng01 with custom theme", res[[1]])
+  })
 })
 
 
 # mng01 ----
 
 test_that("mng01 works as expected with custom color set", {
-  col <- c(
-    "B: Placebo" = "black",
-    "A: Drug X" = "blue",
-    "C: Combination" = "gray"
-  )
+  withr::with_options(opts_partial_match_old, {
+    col <- c(
+      "B: Placebo" = "black",
+      "A: Drug X" = "blue",
+      "C: Combination" = "gray"
+    )
+    proc_data <- syn_data
 
-  proc_data <- syn_data
-  res <- run(mng01, proc_data, dataset = "adlb", line_col = col)
-  expect_list(res, len = 3, types = "ggplot")
+    res <- run(mng01, proc_data, dataset = "adlb", line_col = col)
+    expect_list(res, len = 3, types = "ggplot")
 
-  res2 <- run(mng01, proc_data, dataset = "adlb", line_col = unname(col))
-  expect_list(res2, len = 3, types = "ggplot")
+    res2 <- run(mng01, proc_data, dataset = "adlb", line_col = unname(col))
+    expect_list(res2, len = 3, types = "ggplot")
 
-  skip_on_ci()
-  vdiffr::expect_doppelganger("run mng01 with custom color set", res[[1]])
-  vdiffr::expect_doppelganger("run mng01 with custom unnamed color set", res2[[1]])
+    skip_on_ci()
+    vdiffr::expect_doppelganger("run mng01 with custom color set", res[[1]])
+    vdiffr::expect_doppelganger("run mng01 with custom unnamed color set", res2[[1]])
+  })
 })
 
 test_that("mng01 works with table = NULL", {
-  proc_data <- syn_data
-  res <- run(mng01, proc_data, dataset = "adlb", table = NULL)
-  expect_list(res, len = 3, types = "ggplot")
+  withr::with_options(opts_partial_match_old, {
+    proc_data <- syn_data
+    res <- run(mng01, proc_data, dataset = "adlb", table = NULL)
+    expect_list(res, len = 3, types = "ggplot")
 
-  skip_on_ci()
-  vdiffr::expect_doppelganger("run mng01 without table", res[[1]])
+    skip_on_ci()
+    vdiffr::expect_doppelganger("run mng01 without table", res[[1]])
+  })
 })
 
 test_that("mng01 works with combination of x variables", {
-  proc_data <- syn_data
-  res <- run(
-    mng01,
-    proc_data,
-    dataset = "adlb",
-    x_var = c("AVISIT", "AVISITN")
-  )
-  expect_list(res, len = 3, types = "ggplot")
+  withr::with_options(opts_partial_match_old, {
+    proc_data <- syn_data
+    res <- run(
+      mng01,
+      proc_data,
+      dataset = "adlb",
+      x_var = c("AVISIT", "AVISITN")
+    )
 
-  skip_on_ci()
-  vdiffr::expect_doppelganger("run mng01 with combination of x variables", res[[1]])
+    expect_list(res, len = 3, types = "ggplot")
+
+    skip_on_ci()
+    vdiffr::expect_doppelganger("run mng01 with combination of x variables", res[[1]])
+  })
 })
 
 test_that("mng01 works with numeric x variable", {
-  proc_data <- syn_data
-  proc_data$adlb$AVISITN[1:20] <- 10
-  proc_data$adlb$AVISITN[21:40] <- -3
-  res <- run(
-    mng01,
-    proc_data,
-    dataset = "adlb",
-    x_var = c("AVISITN")
-  )
-  expect_list(res, len = 3, types = "ggplot")
+  withr::with_options(opts_partial_match_old, {
+    proc_data <- syn_data
+    proc_data$adlb$AVISITN[1:20] <- 10
+    proc_data$adlb$AVISITN[21:40] <- -3
 
-  skip_on_ci()
-  vdiffr::expect_doppelganger("run mng01 with numeric x variables", res[[1]])
+    res <- run(
+      mng01,
+      proc_data,
+      dataset = "adlb",
+      x_var = c("AVISITN")
+    )
+
+    expect_list(res, len = 3, types = "ggplot")
+
+    skip_on_ci()
+    vdiffr::expect_doppelganger("run mng01 with numeric x variables", res[[1]])
+  })
 })
 
 test_that("mng01 works with numeric jitter", {
-  proc_data <- syn_data
-  res <- run(
-    mng01,
-    proc_data,
-    dataset = "adlb",
-    jitter = 0.7
-  )
-  expect_list(res, len = 3, types = "ggplot")
+  withr::with_options(opts_partial_match_old, {
+    proc_data <- syn_data
 
-  skip_on_ci()
-  vdiffr::expect_doppelganger("run mng01 with jitter", res[[1]])
+    res <- run(
+      mng01,
+      proc_data,
+      dataset = "adlb",
+      jitter = 0.7
+    )
+
+    expect_list(res, len = 3, types = "ggplot")
+    skip_on_ci()
+    vdiffr::expect_doppelganger("run mng01 with jitter", res[[1]])
+  })
 })


### PR DESCRIPTION
ignore `justification` argument missmatch inside the `grid` or `cowplot` package.

thank you for the review