### PR TITLE
Fix class error@main

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # chevron 0.2.8.9007
 
 * `ttet01_main` now prints a clearer error message when a level in `arm_var` variable is missing.
+* Bug fix: `lbt05` now prints a clearer error message when `PARAM`, `AVALCAT1` and `ABN_DIR` variables in `adlb` are not of class `factor`. 
 
 # chevron 0.2.8
 

--- a/R/lbt04.R
+++ b/R/lbt04.R
@@ -35,7 +35,7 @@ lbt04_main <- function(adam_db,
   assert_string(row_split_var)
   assert_valid_variable(
     adam_db$adlb, c("PARAMCD", "PARAM", row_split_var),
-    types = list("characater", "factor")
+    types = list(c("character", "factor"))
   )
   assert_subset(page_var, row_split_var)
   assert_valid_variable(adam_db$adlb, c("USUBJID"), types = list(c("character", "factor")), empty_ok = TRUE)

--- a/R/lbt05.R
+++ b/R/lbt05.R
@@ -23,7 +23,8 @@ lbt05_main <- function(adam_db,
   assert_all_tablenames(adam_db, c("adsl", "adlb"))
   assert_string(arm_var)
   assert_string(lbl_overall, null.ok = TRUE)
-  assert_valid_variable(adam_db$adlb, c("PARAM", "AVALCAT1", "ABN_DIR"), types = list(c("character", "factor")))
+  # expand.grid steps requires levels later.
+  assert_valid_variable(adam_db$adlb, c("PARAM", "AVALCAT1", "ABN_DIR"), types = list("factor"))
   assert_valid_variable(adam_db$adlb, c("USUBJID"), types = list(c("character", "factor")), empty_ok = TRUE)
   assert_valid_variable(adam_db$adsl, c("USUBJID"), types = list(c("character", "factor")))
   assert_valid_var_pair(adam_db$adsl, adam_db$adlb, arm_var)
@@ -37,7 +38,7 @@ lbt05_main <- function(adam_db,
     ABN_DIR = c("Low", "High"),
     stringsAsFactors = FALSE
   ) %>%
-    arrange(.data$PARAM, desc(.data$ABN_DIR))
+  arrange(.data$PARAM, desc(.data$ABN_DIR))
 
   lyt <- lbt05_lyt(
     arm_var = arm_var,

--- a/R/lbt05.R
+++ b/R/lbt05.R
@@ -38,7 +38,7 @@ lbt05_main <- function(adam_db,
     ABN_DIR = c("Low", "High"),
     stringsAsFactors = FALSE
   ) %>%
-  arrange(.data$PARAM, desc(.data$ABN_DIR))
+    arrange(.data$PARAM, desc(.data$ABN_DIR))
 
   lyt <- lbt05_lyt(
     arm_var = arm_var,

--- a/tests/testthat/_snaps/lbt05.md
+++ b/tests/testthat/_snaps/lbt05.md
@@ -94,3 +94,39 @@
             Last or replicated                     3 (23.1%)   4 (28.6%)      3 (21.4%)   
             Any Abnormality                        9 (69.2%)   5 (35.7%)      5 (35.7%)   
 
+# lbt05 works with missing levels
+
+    Code
+      cat(export_as_txt(res, lpp = 100))
+    Output
+        Laboratory Test                            A: Drug X   B: Placebo   C: Combination
+            Direction of Abnormality                (N=15)       (N=15)         (N=15)    
+        ——————————————————————————————————————————————————————————————————————————————————
+        Alanine Aminotransferase Measurement (n)       0           0              0       
+          Low                                                                             
+            Single, not last                           0           0              0       
+            Last or replicated                         0           0              0       
+            Any Abnormality                            0           0              0       
+          High                                                                            
+            Single, not last                           0           0              0       
+            Last or replicated                         0           0              0       
+            Any Abnormality                            0           0              0       
+        C-Reactive Protein Measurement (n)             0           0              0       
+          Low                                                                             
+            Single, not last                           0           0              0       
+            Last or replicated                         0           0              0       
+            Any Abnormality                            0           0              0       
+          High                                                                            
+            Single, not last                           0           0              0       
+            Last or replicated                         0           0              0       
+            Any Abnormality                            0           0              0       
+        Immunoglobulin A Measurement (n)              13           14             14      
+          Low                                                                             
+            Single, not last                           0           0              0       
+            Last or replicated                         0           0              0       
+            Any Abnormality                            0           0              0       
+          High                                                                            
+            Single, not last                       6 (46.2%)    1 (7.1%)      2 (14.3%)   
+            Last or replicated                     3 (23.1%)   4 (28.6%)      3 (21.4%)   
+            Any Abnormality                        9 (69.2%)   5 (35.7%)      5 (35.7%)   
+

--- a/tests/testthat/test-lbt05.R
+++ b/tests/testthat/test-lbt05.R
@@ -45,3 +45,12 @@ test_that("lbt05 fails on incomlete data", {
     mutate(PARCAT2 = NULL)
   expect_error(run(lbt05, proc_data))
 })
+
+test_that("lbt05 works with missing levels", {
+  skip_on_os("windows")
+  proc_data <- syn_data
+  proc_data$adlb <- proc_data$adlb %>%
+    filter(PARAM == "Immunoglobulin A Measurement")
+  res <- expect_silent(run(lbt05, proc_data))
+  expect_snapshot(cat(export_as_txt(res, lpp = 100)))
+})


### PR DESCRIPTION
bug spotted by @barnett11 in lbt05

```
The error I see is below,
Error in `arrange()`:
! Can't transform a data frame with `NA` or `""` names.
Run `rlang::last_trace()` to see where the error occurred.

I believe I've located issue at this section specifically within the main function,
map <- expand.grid(PARAM = levels(adam_db$adlb$PARAM), ABN_DIR = c("Low", 
        "High"), stringsAsFactors = FALSE) %>% arrange(.data$PARAM, 
        desc(.data$ABN_DIR))
```

This is due to the fact the `PARAM` is expected to be a factor by the `level` function. Automatic conversion to factor can cause unexpected behavior and is, in general, avoided.

Defensive approach is to modify the assertion to force `PARAM` to be a factor. 
- adapt assertion
- add tests

thank you for the review
