### PR TITLE
Remove lookup-refs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,13 +26,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/tern
-        insightsengineering/dunlin
-        insightsengineering/rtables
-        insightsengineering/rlistings
-        insightsengineering/formatters
-        insightsengineering/nestcolor
       additional-env-vars: |
         _R_CHECK_CRAN_INCOMING_REMOTE_=false
       additional-r-cmd-check-params: --as-cran
@@ -55,13 +48,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/tern
-        insightsengineering/dunlin
-        insightsengineering/rtables
-        insightsengineering/rlistings
-        insightsengineering/formatters
-        insightsengineering/nestcolor
       additional-env-vars: |
         NOT_CRAN=true
       enforce-note-blocklist: true
@@ -84,13 +70,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/tern
-        insightsengineering/dunlin
-        insightsengineering/rtables
-        insightsengineering/rlistings
-        insightsengineering/formatters
-        insightsengineering/nestcolor
       additional-env-vars: |
         NOT_CRAN=true
   linter:
@@ -104,13 +83,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/tern
-        insightsengineering/dunlin
-        insightsengineering/rtables
-        insightsengineering/rlistings
-        insightsengineering/formatters
-        insightsengineering/nestcolor
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,12 +39,5 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/tern
-        insightsengineering/dunlin
-        insightsengineering/rtables
-        insightsengineering/rlistings
-        insightsengineering/formatters
-        insightsengineering/nestcolor
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -64,10 +64,3 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/dunlin
-        insightsengineering/formatters
-        insightsengineering/rlistings
-        insightsengineering/rtables
-        insightsengineering/tern


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 
```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CJ Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.